### PR TITLE
Fix some typos in ecosystem.html

### DIFF
--- a/_includes/ecosystem.html
+++ b/_includes/ecosystem.html
@@ -94,8 +94,8 @@
                 </h4>
                 <p>
                   Julia provides powerful tools for deep learning (
-                  <a href = "https://github.com/FluxML/Flux.jl"> Flux and 
-                    <a href = "https://github.com/denizyuret/Knet.jl"> Knet </a>),
+                    <a href = "https://github.com/FluxML/Flux.jl">Flux</a> and 
+                    <a href = "https://github.com/denizyuret/Knet.jl">Knet </a>),
                   <a href = "http://juliaml.github.io"> machine learning </a> and AI. Julia’s mathematical syntax makes it an ideal way to express algorithms just as they are written in papers, build trainable models with
                   <a href = "http://www.juliadiff.org">automatic differentiation</a>,
                   <a href = "https://github.com/JuliaGPU/CuArrays.jl">GPU acceleration</a> and support for terabytes of data.
@@ -126,8 +126,8 @@
                   This can be seen in the abundance of scientific tooling written in Julia, such as the state-of-the-art
                   differential equations ecosystem  
                   <a href = "">(DiffEq)</a>, optimization tools (
-                  <a href = "">JuMP</a> and
-                  <a href = ""> Optim </a>), iterative linear solvers 
+                  <a href = "">JuMP</a> and 
+                  <a href = "">Optim </a>), iterative linear solvers 
                   <a href = "">(IterativeSolvers)</a> and many more, that can drive all your simulations. 
                   </p>
                   Julia also offers a number of domain-specific ecosystems, such as in biology 
@@ -136,7 +136,7 @@
                   <a href = "https://github.com/qojulia/QuantumOptics.jl"> (QuantumOptics) </a>, quantitative economics
                   <a href = "https://github.com/QuantEcon">(QuantEcon)</a>, astronomy
                   <a href = "http://juliaastro.github.io"> (JuliaAstro)</a></li> or ecology
-                  <a href = "https://github.com/EcoJulia">(JuliaEco) </a></li>. With a set of highly enthused set of
+                  <a href = "https://github.com/EcoJulia">(EcoJulia) </a></li>. With a set of highly enthused set of
                   developers and maintainers from various parts of the scientific community, this ecosystem will only continue to get
                   bigger and bigger. 
                 </p>


### PR DESCRIPTION
This changes `JuliaEco` to `EcoJulia`, and closes a `a` tag.